### PR TITLE
Move slider dots outside slides

### DIFF
--- a/home.html
+++ b/home.html
@@ -145,7 +145,6 @@
                   </ul>
                 </div>
               </div>
-              <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
             </div>
 
             <!-- Slide 2: Devil Square -->
@@ -161,7 +160,6 @@
                   </ul>
                 </div>
               </div>
-              <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
             </div>
 
             <!-- Slide 3: PK -->
@@ -177,7 +175,6 @@
                   </ul>
                 </div>
               </div>
-              <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
             </div>
 
             <!-- Slide 4: Resets -->
@@ -193,9 +190,9 @@
                   </ul>
                 </div>
               </div>
-              <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
             </div>
           </div>
+          <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
         </div>
       </div>
     </section>
@@ -241,5 +238,23 @@
       <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
     </div>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      const slider = document.querySelector('.slider');
+      if(!slider) return;
+      const slides = slider.querySelectorAll('.slide');
+      const dots = slider.querySelectorAll('.dot');
+      const slidesContainer = slider.querySelector('.slides');
+      const duration = parseFloat(getComputedStyle(slidesContainer).animationDuration) * 1000;
+      const interval = duration / slides.length;
+      let index = 0;
+      function activate(){
+        dots.forEach((d,i)=>d.classList.toggle('active', i===index));
+        index = (index + 1) % dots.length;
+      }
+      activate();
+      setInterval(activate, interval);
+    });
+  </script>
 </body>
 </html>

--- a/index_bootstrap.html
+++ b/index_bootstrap.html
@@ -193,11 +193,12 @@
                         <li><strong>Top 2:</strong> <span class="name">nick2</span> <span class="class-badge elf" title="Elf" aria-label="Elf"></span></li>
                         <li><strong>Top 3:</strong> <span class="name">nick3</span> <span class="class-badge sm" title="SM" aria-label="SM"></span></li>
                       </ul>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
+            </div>
+            <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+          </div>
 
           </div>
         </section>
@@ -247,5 +248,23 @@
       <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
     </div>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      const slider = document.querySelector('.slider');
+      if(!slider) return;
+      const slides = slider.querySelectorAll('.slide');
+      const dots = slider.querySelectorAll('.dot');
+      const slidesContainer = slider.querySelector('.slides');
+      const duration = parseFloat(getComputedStyle(slidesContainer).animationDuration) * 1000;
+      const interval = duration / slides.length;
+      let index = 0;
+      function activate(){
+        dots.forEach((d,i)=>d.classList.toggle('active', i===index));
+        index = (index + 1) % dots.length;
+      }
+      activate();
+      setInterval(activate, interval);
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -105,8 +105,9 @@ a{color:inherit;text-decoration:none}
 .class-badge.sm{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%23131d26%22/><text x=%224%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>SM</text></svg>')}
 .class-badge.elf{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%23162318%22/><text x=%224%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>EL</text></svg>')}
 .class-badge.mg{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%231a1a1a%22/><text x=%224%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>MG</text></svg>')}
-.dots{position:absolute;right:8px;bottom:8px;display:flex;gap:.4rem}
-.dot{width:10px;height:10px;border-radius:999px;border:1px solid var(--border);background:#0b0b0e;opacity:.8}
+.dots{position:absolute;bottom:8px;left:0;right:0;display:flex;justify-content:center;gap:.4rem;z-index:5}
+.dot{width:10px;height:10px;border-radius:999px;border:1px solid var(--border);background:#0b0b0e;opacity:.4;transition:opacity .3s,background .3s}
+.dot.active{background:var(--accent);opacity:1}
 .slider:hover .slides{animation-play-state:paused}
 
 /* ornament / boundary cues for slider */


### PR DESCRIPTION
## Summary
- Consolidate slider navigation dots into one container per slider
- Center dots via CSS and add active state styling
- Add small script to sync active dot with slides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36126df188323b24e4ed2a625244c