### PR TITLE
Add accessible slider pause control

### DIFF
--- a/home.html
+++ b/home.html
@@ -93,12 +93,12 @@
       <section class="card" aria-labelledby="info-ttl">
         <header class="card__hdr"><h2 id="info-ttl" class="card__title">Informações</h2></header>
         <div class="card__body" style="display:grid;gap:1.34rem">
-          <div class="events__row"><span>Versão</span><span class="pill">97d+99i</span></div>
-          <div class="events__row"><span>Experiência</span><span class="pill">100x</span></div>
-          <div class="events__row"><span>Drop</span><span class="pill">30%</span></div>
-          <div class="events__row"><span>Total de Contas</span><span class="pill">89</span></div>
-          <div class="events__row"><span>Total de Personagens</span><span class="pill">21</span></div>
-          <div class="events__row"><span>Total de Guilds</span><span class="pill">5</span></div>
+          <div class="info__row"><span>Versão</span><span class="pill">97d+99i</span></div>
+          <div class="info__row"><span>Experiência</span><span class="pill">100x</span></div>
+          <div class="info__row"><span>Drop</span><span class="pill">30%</span></div>
+          <div class="info__row"><span>Total de Contas</span><span class="pill">89</span></div>
+          <div class="info__row"><span>Total de Personagens</span><span class="pill">21</span></div>
+          <div class="info__row"><span>Total de Guilds</span><span class="pill">5</span></div>
         </div>
       </section>
     </div>
@@ -131,6 +131,7 @@
 
         <!-- Slider CSS TOP 1-3 (auto-rotação) -->
         <div class="slider" role="region" aria-label="Top 1-3 dos Rankings">
+          <button class="slider__toggle" type="button" aria-label="Pause animation">Pause</button>
           <div class="slides">
             <!-- Slide 1: Blood Castle -->
             <div class="slide">
@@ -226,7 +227,7 @@
           <a class="rank-card" href="#downloads"><strong>Downloads</strong><small>Cliente, patch, anti-cheat</small></a>
           <a class="rank-card" href="#regras"><strong>Regras</strong><small>Jogabilidade e conduta</small></a>
           <a class="rank-card" href="#discord"><strong>Discord</strong><small>Suporte e comunidade</small></a>
-          <div class="events__row"><span>Dica do Dia</span><span class="pill">Use /post com moderação</span></div>
+          <div class="guide__row"><span>Dica do Dia</span><span class="pill">Use /post com moderação</span></div>
         </div>
       </section>
     </div>
@@ -245,6 +246,7 @@
       const slides = slider.querySelectorAll('.slide');
       const dots = slider.querySelectorAll('.dot');
       const slidesContainer = slider.querySelector('.slides');
+      const toggleBtn = slider.querySelector('.slider__toggle');
       const duration = parseFloat(getComputedStyle(slidesContainer).animationDuration) * 1000;
       const interval = duration / slides.length;
       let index = 0;
@@ -254,6 +256,20 @@
       }
       activate();
       setInterval(activate, interval);
+      if(toggleBtn){
+        toggleBtn.addEventListener('click', ()=>{
+          const paused = slidesContainer.style.animationPlayState === 'paused';
+          if(paused){
+            slidesContainer.style.animationPlayState = '';
+            toggleBtn.setAttribute('aria-label','Pause animation');
+            toggleBtn.textContent = 'Pause';
+          }else{
+            slidesContainer.style.animationPlayState = 'paused';
+            toggleBtn.setAttribute('aria-label','Play animation');
+            toggleBtn.textContent = 'Play';
+          }
+        });
+      }
     });
   </script>
 </body>

--- a/index_bootstrap.html
+++ b/index_bootstrap.html
@@ -93,12 +93,12 @@
           <section class="card flex-fill" aria-labelledby="info-ttl">
             <header class="card__hdr"><h2 id="info-ttl" class="card__title m-0">Informações</h2></header>
             <div class="card__body d-grid gap-2">
-              <div class="events__row"><span>Versão</span><span class="pill">97d+99i</span></div>
-              <div class="events__row"><span>Experiência</span><span class="pill">100x</span></div>
-              <div class="events__row"><span>Drop</span><span class="pill">30%</span></div>
-              <div class="events__row"><span>Total de Contas</span><span class="pill">89</span></div>
-              <div class="events__row"><span>Total de Personagens</span><span class="pill">21</span></div>
-              <div class="events__row"><span>Total de Guilds</span><span class="pill">5</span></div>
+              <div class="info__row"><span>Versão</span><span class="pill">97d+99i</span></div>
+              <div class="info__row"><span>Experiência</span><span class="pill">100x</span></div>
+              <div class="info__row"><span>Drop</span><span class="pill">30%</span></div>
+              <div class="info__row"><span>Total de Contas</span><span class="pill">89</span></div>
+              <div class="info__row"><span>Total de Personagens</span><span class="pill">21</span></div>
+              <div class="info__row"><span>Total de Guilds</span><span class="pill">5</span></div>
             </div>
           </section>
         </div>
@@ -136,6 +136,7 @@
 
             <!-- Slider -->
             <div class="slider glow" role="region" aria-label="Top 1-3 dos Rankings">
+              <button class="slider__toggle" type="button" aria-label="Pause animation">Pause</button>
               <div class="slides">
                 <!-- Slide 1: Blood Castle -->
                 <div class="slide">
@@ -234,7 +235,7 @@
               <a class="rank-card" href="#downloads"><strong>Downloads</strong><small>Cliente, patch, anti-cheat</small></a>
               <a class="rank-card" href="#regras"><strong>Regras</strong><small>Jogabilidade e conduta</small></a>
               <a class="rank-card" href="#discord"><strong>Discord</strong><small>Suporte e comunidade</small></a>
-              <div class="events__row"><span>Dica do Dia</span><span class="pill">Use /post com moderação</span></div>
+              <div class="guide__row"><span>Dica do Dia</span><span class="pill">Use /post com moderação</span></div>
             </div>
           </section>
         </div>
@@ -255,6 +256,7 @@
       const slides = slider.querySelectorAll('.slide');
       const dots = slider.querySelectorAll('.dot');
       const slidesContainer = slider.querySelector('.slides');
+      const toggleBtn = slider.querySelector('.slider__toggle');
       const duration = parseFloat(getComputedStyle(slidesContainer).animationDuration) * 1000;
       const interval = duration / slides.length;
       let index = 0;
@@ -264,6 +266,20 @@
       }
       activate();
       setInterval(activate, interval);
+      if(toggleBtn){
+        toggleBtn.addEventListener('click', ()=>{
+          const paused = slidesContainer.style.animationPlayState === 'paused';
+          if(paused){
+            slidesContainer.style.animationPlayState = '';
+            toggleBtn.setAttribute('aria-label','Pause animation');
+            toggleBtn.textContent = 'Pause';
+          }else{
+            slidesContainer.style.animationPlayState = 'paused';
+            toggleBtn.setAttribute('aria-label','Play animation');
+            toggleBtn.textContent = 'Play';
+          }
+        });
+      }
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -71,7 +71,9 @@ a{color:inherit;text-decoration:none}
 
 /* ---------- Events ---------- */
 .events{display:grid;gap:.6rem}
-.events__row{display:flex;justify-content:space-between;align-items:center;padding:.7rem .75rem;border:1px dashed var(--border);border-radius:.6rem;background:#12121a}
+.events__row,
+.info__row,
+.guide__row{display:flex;justify-content:space-between;align-items:center;padding:.7rem .75rem;border:1px dashed var(--border);border-radius:.6rem;background:#12121a}
 .events__title{font-weight:800}
 .events__meta{display:flex;gap:.5rem;align-items:center;color:var(--muted);font-size:.85rem}
 .events__count{font-weight:900}
@@ -109,6 +111,12 @@ a{color:inherit;text-decoration:none}
 .dot{width:10px;height:10px;border-radius:999px;border:1px solid var(--border);background:#0b0b0e;opacity:.4;transition:opacity .3s,background .3s}
 .dot.active{background:var(--accent);opacity:1}
 .slider:hover .slides{animation-play-state:paused}
+.slider:focus-within .slides{animation-play-state:paused}
+.slider__toggle{
+  position:absolute;
+  width:1px;height:1px;margin:-1px;border:0;padding:0;
+  clip:rect(0 0 0 0);clip-path:inset(50%);overflow:hidden;white-space:nowrap
+}
 
 /* ornament / boundary cues for slider */
 .slider::before{content:"";position:absolute;inset:0;pointer-events:none;background:


### PR DESCRIPTION
## Summary
- Pause slider animation when any element within the slider gains focus and provide hidden Pause/Play control
- Split shared row styling into dedicated classes so info and guide texts can be colored separately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3652cf09c83239d13f800f4f26780