### PR TITLE
Ajustes de responsividade e melhorias visuais do painel

### DIFF
--- a/index_bootstrap.html
+++ b/index_bootstrap.html
@@ -84,13 +84,14 @@
                   <span class="muted">Senha</span>
                   <input class="input" type="password" name="password" placeholder="••••••••" aria-label="Senha" />
                 </label>
-                <button class="btn btn--primary" type="button" aria-disabled="true" title="Somente layout — implemente o backend com segurança">Entrar</button>
+                <button class="btn btn--primary" type="button">Entrar</button>
+                <button class="btn btn--secondary" type="button">Cadastrar</button>
                 <p class="hint">⚠️ Ilustrativo. Ao implementar, use HTTPS, CSRF, rate limit e hashing forte (Argon2/BCrypt).</p>
               </form>
             </div>
           </section>
 
-          <section class="card flex-fill" aria-labelledby="info-ttl">
+          <section class="card flex-fill glow" aria-labelledby="info-ttl">
             <header class="card__hdr"><h2 id="info-ttl" class="card__title m-0">Informações</h2></header>
             <div class="card__body d-grid gap-2">
               <div class="info__row"><span>Versão</span><span class="pill">97d+99i</span></div>

--- a/style.css
+++ b/style.css
@@ -12,19 +12,25 @@ a{color:inherit;text-decoration:none}
 /* ---------- Paleta ---------- */
 :root{
   --bg:#0b0b0e; --panel:#0000; --panel2:#151520; --card:#14141b; --txt:#e9e9f0; --muted:#a6a6b3;
-  --primary:#ef4444; --primary-700:#b91c1c; --accent:#f59e0b; --border:#262635;
+  --primary:#ef4444; --primary-700:#b91c1c; --accent:#f59e0b; --accent-700:#d97706; --border:#262635;
 }
 
 .container{width:min(1200px,100%);margin-inline:auto;padding-inline:1rem}
 
 /* ---------- Header ---------- */
 .topbar{position:sticky;top:0;z-index:50;background:linear-gradient(180deg,rgba(0,0,0,.9),rgba(0,0,0,.6));backdrop-filter:saturate(140%) blur(6px);border-bottom:1px solid var(--border)}
-.nav{height:64px;display:flex;align-items:center;justify-content:space-between;gap:1rem}
+.nav{height:64px;display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap}
 .brand{display:flex;align-items:center;gap:.75rem;font-weight:800;letter-spacing:.5px}
 .brand__badge{width:36px;aspect-ratio:1;border-radius:8px;background:radial-gradient(circle at 30% 30%, #7f1d1d, #111);border:1px solid var(--border);display:grid;place-items:center}
 .menu{display:flex;gap:.75rem;flex-wrap:wrap}
 .menu a{padding:.5rem .75rem;border-radius:.5rem;border:1px solid transparent}
 .menu a:hover{background:#151520;border-color:var(--border)}
+
+@media (max-width:480px){
+  .nav{height:auto;flex-direction:column;align-items:flex-start;padding-block:.5rem}
+  .menu{width:100%;flex-direction:column}
+  .menu a{width:100%}
+}
 
 /* ---------- Hero ---------- */
 .hero{min-height:200px;display:grid;place-items:center;border-bottom:1px solid var(--border);background:
@@ -64,9 +70,12 @@ a{color:inherit;text-decoration:none}
 .form{display:grid;gap:.6rem}
 .form label{display:grid;gap:.35rem}
 .input{background:var(--panel);border:1px solid var(--border);border-radius:.6rem;padding:.55rem .7rem;color:var(--txt);width:100%}
+.input:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 2px rgba(245,158,11,.3)}
 .btn{cursor:pointer;border:0;padding:.55rem .8rem;border-radius:.6rem;font-weight:800;letter-spacing:.3px}
 .btn--primary{background:var(--primary);color:#fff}
 .btn--primary:hover{background:var(--primary-700)}
+.btn--secondary{background:var(--accent);color:#000}
+.btn--secondary:hover{background:var(--accent-700)}
 .hint{color:var(--muted);font-size:.8rem}
 
 /* ---------- Events ---------- */
@@ -77,6 +86,9 @@ a{color:inherit;text-decoration:none}
 .events__title{font-weight:800}
 .events__meta{display:flex;gap:.5rem;align-items:center;color:var(--muted);font-size:.85rem}
 .events__count{font-weight:900}
+
+.info__row{border-color:var(--accent);background:#14141b}
+.info__row .pill{background:var(--accent);color:#000;font-weight:700}
 
 /* ---------- Rank hub ---------- */
 .rank-grid{display:grid;grid-template-columns:1fr;gap:.75rem}


### PR DESCRIPTION
## Resumo
- Remove tooltip e adiciona botão de cadastro abaixo de **Entrar**
- Ajusta header para telas pequenas e destaca formulário ao focar
- Realça área de informações com borda animada e cores de destaque

## Testes
- `npm test` *(erro: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a383e071d0832397ac0d09389805ab