### PR TITLE
Reestrutura ranking e adiciona páginas básicas

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bakasta Mu — Downloads</title>
+  <meta name="description" content="Downloads do Bakasta Mu." />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container nav" role="navigation" aria-label="Navegação principal">
+      <a class="brand" href="index_bootstrap.html">
+        <span class="brand__badge">
+          <img src="img/logo.png" alt="Logo Bakasta Mu" />
+        </span>
+        <span>Bakasta <span class="muted">Mu</span></span>
+      </a>
+      <nav class="menu" aria-label="Menu">
+        <a href="index_bootstrap.html#home">Início</a>
+        <a href="downloads.html">Downloads</a>
+        <a href="index_bootstrap.html#ranking">Ranking</a>
+        <a href="usuario.html">Usuário</a>
+        <a href="info.html">Informações</a>
+        <a href="#vip">Comprar VIP</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="container text-center py-4">
+      <h1>Downloads</h1>
+    </div>
+  </section>
+
+  <main class="container my-4">
+    <section class="card" aria-labelledby="downloads-ttl">
+      <header class="card__hdr"><h2 id="downloads-ttl" class="card__title m-0">Downloads</h2></header>
+      <div class="card__body">
+        <p>Conteúdo de downloads em breve.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>© <span id="y">2025</span> Bakasta Mu. Fan project sem vínculo com Webzen — marcas são de seus respectivos donos.</p>
+      <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
+    </div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/index_bootstrap.html
+++ b/index_bootstrap.html
@@ -14,17 +14,18 @@
   <!-- Header -->
   <header class="topbar">
     <div class="container nav" role="navigation" aria-label="Navegação principal">
-      <a class="brand" href="#">
+      <a class="brand" href="index_bootstrap.html">
         <span class="brand__badge">
           <img src="img/logo.png" alt="Logo Bakasta Mu" />
         </span>
         <span>Bakasta <span class="muted">Mu</span></span>
       </a>
       <nav class="menu" aria-label="Menu">
-        <a href="#home">Início</a>
-        <a href="#downloads">Downloads</a>
+        <a href="index_bootstrap.html#home">Início</a>
+        <a href="downloads.html">Downloads</a>
         <a href="#ranking">Ranking</a>
-        <a href="#info">Informações</a>
+        <a href="usuario.html">Usuário</a>
+        <a href="info.html">Informações</a>
         <a href="#vip">Comprar VIP</a>
       </nav>
     </div>
@@ -50,23 +51,46 @@
             <h2 id="ttl-news" class="card__title m-0">Últimas Notícias</h2>
             <span class="pill">Feed</span>
           </header>
-          <div class="card__body news">
-            <article class="news__item">
-              <div class="news__icon" aria-hidden="true">★</div>
-              <div>
-                <h3 class="news__title">Bem-vindos ao Bakasta Mu</h3>
-                <div class="news__meta">Postado por <strong>Admin</strong> em 18/07/2025 04:53</div>
-                <p class="news__excerpt">Layout limpo e responsivo. Conteúdo dinâmico virá do backend.</p>
+          <div class="card__body">
+            <div class="news">
+              <article class="news__item">
+                <div class="news__icon" aria-hidden="true">★</div>
+                <div>
+                  <h3 class="news__title">Bem-vindos ao Bakasta Mu</h3>
+                  <div class="news__meta">Postado por <strong>Admin</strong> em 18/07/2025 04:53</div>
+                  <p class="news__excerpt">Layout limpo e responsivo. Conteúdo dinâmico virá do backend.</p>
+                </div>
+              </article>
+              <article class="news__item">
+                <div class="news__icon" aria-hidden="true">★</div>
+                <div>
+                  <h3 class="news__title">Eventos em ciclos</h3>
+                  <div class="news__meta">Postado por <strong>Admin</strong> em 03/09/2025 19:21</div>
+                  <p class="news__excerpt">Estrutura pronta para countdown com horários e intervalos.</p>
+                </div>
+              </article>
+            </div>
+            <div id="newsCarousel" class="carousel slide mt-3" data-bs-ride="carousel">
+              <div class="carousel-inner">
+                <div class="carousel-item active">
+                  <img src="img/slide1.jpg" class="d-block w-100" alt="Imagem 1" />
+                </div>
+                <div class="carousel-item">
+                  <img src="img/slide2.jpeg" class="d-block w-100" alt="Imagem 2" />
+                </div>
+                <div class="carousel-item">
+                  <img src="img/slide3.png" class="d-block w-100" alt="Imagem 3" />
+                </div>
               </div>
-            </article>
-            <article class="news__item">
-              <div class="news__icon" aria-hidden="true">★</div>
-              <div>
-                <h3 class="news__title">Eventos em ciclos</h3>
-                <div class="news__meta">Postado por <strong>Admin</strong> em 03/09/2025 19:21</div>
-                <p class="news__excerpt">Estrutura pronta para countdown com horários e intervalos.</p>
-              </div>
-            </article>
+              <button class="carousel-control-prev" type="button" data-bs-target="#newsCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Anterior</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#newsCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Próximo</span>
+              </button>
+            </div>
           </div>
         </section>
       </div>
@@ -117,101 +141,25 @@
             <h2 id="ranks-title" class="card__title m-0">Rankings</h2>
             <span class="pill">Hall, PK, Eventos</span>
           </header>
-          <div class="card__body d-flex flex-column gap-3">
+          <div class="card__body">
             <div class="rank-grid">
-              <a class="rank-card" href="#ranking-bc" aria-label="Ranking Blood Castle">
+              <div class="rank-card">
                 <strong>Blood Castle</strong>
-                <small>Top pontuações e vitórias</small>
-              </a>
-              <a class="rank-card" href="#ranking-ds" aria-label="Ranking Devil Square">
+                <div>Top 1: <span class="name">nick1</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></div>
+              </div>
+              <div class="rank-card">
                 <strong>Devil Square</strong>
-                <small>Maior tempo e kills</small>
-              </a>
-              <a class="rank-card" href="#ranking-pk" aria-label="Ranking PK">
+                <div>Top 1: <span class="name">nick1</span> <span class="class-badge mg" title="MG" aria-label="MG"></span></div>
+              </div>
+              <div class="rank-card">
                 <strong>Ranking PK</strong>
-                <small>Players com mais PKs</small>
-              </a>
-              <a class="rank-card" href="#ranking-reset" aria-label="Ranking de Resets">
+                <div>Top 1: <span class="name">nick1</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></div>
+              </div>
+              <div class="rank-card">
                 <strong>Resets</strong>
-                <small>Top resets por classe</small>
-              </a>
-            </div>
-
-            <!-- Slider -->
-            <div class="slider glow" role="region" aria-label="Top 1-3 dos Rankings">
-              <button class="slider__toggle" type="button" aria-label="Pause animation">Pause</button>
-              <div class="slides">
-                <!-- Slide 1: Blood Castle -->
-                <div class="slide">
-                  <div class="slide__img">
-                    <img src="/web_Bakasta/BakastaWeb/img/slide1.jpg" alt="Ranking Blood Castle" />
-                  </div>
-                  <div class="legend">
-                    <div class="legend__box">
-                      <div class="legend__head"><span class="legend__icon icon-bc" title="Ranking Blood Castle" aria-hidden="true"></span><h4 class="legend__title">TOP — Blood Castle</h4></div>
-                      <ul class="toplist">
-                        <li><strong>Top 1:</strong> <span class="name">nick1</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></li>
-                        <li><strong>Top 2:</strong> <span class="name">nick2</span> <span class="class-badge sm" title="SM" aria-label="SM"></span></li>
-                        <li><strong>Top 3:</strong> <span class="name">nick3</span> <span class="class-badge elf" title="Elf" aria-label="Elf"></span></li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-
-                <!-- Slide 2: Devil Square -->
-                <div class="slide">
-                  <div class="slide__img">
-                    <img src="img/slide2.jpeg" alt="Ranking Devil Square" />
-                  </div>
-                  <div class="legend">
-                    <div class="legend__box">
-                      <div class="legend__head"><span class="legend__icon icon-ds" title="Ranking Devil Square" aria-hidden="true"></span><h4 class="legend__title">TOP — Devil Square</h4></div>
-                      <ul class="toplist">
-                        <li><strong>Top 1:</strong> <span class="name">nick1</span> <span class="class-badge mg" title="MG" aria-label="MG"></span></li>
-                        <li><strong>Top 2:</strong> <span class="name">nick2</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></li>
-                        <li><strong>Top 3:</strong> <span class="name">nick3</span> <span class="class-badge sm" title="SM" aria-label="SM"></span></li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-
-                <!-- Slide 3: PK -->
-                <div class="slide">
-                  <div class="slide__img">
-                    <img src="img/slide3.png" alt="Ranking PK" />
-                  </div>
-                  <div class="legend">
-                    <div class="legend__box">
-                      <div class="legend__head"><span class="legend__icon icon-pk" title="Ranking PK" aria-hidden="true"></span><h4 class="legend__title">TOP — Ranking PK</h4></div>
-                      <ul class="toplist">
-                        <li><strong>Top 1:</strong> <span class="name">nick1</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></li>
-                        <li><strong>Top 2:</strong> <span class="name">nick2</span> <span class="class-badge elf" title="Elf" aria-label="Elf"></span></li>
-                        <li><strong>Top 3:</strong> <span class="name">nick3</span> <span class="class-badge sm" title="SM" aria-label="SM"></span></li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-
-                <!-- Slide 4: Resets -->
-                <div class="slide">
-                  <div class="slide__img">
-                    <img src="img/slide4.jpg" alt="Ranking Resets" />
-                  </div>
-                  <div class="legend">
-                    <div class="legend__box">
-                      <div class="legend__head"><span class="legend__icon icon-resets" title="Ranking Resets" aria-hidden="true"></span><h4 class="legend__title">TOP — Resets</h4></div>
-                      <ul class="toplist">
-                        <li><strong>Top 1:</strong> <span class="name">nick1</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></li>
-                        <li><strong>Top 2:</strong> <span class="name">nick2</span> <span class="class-badge elf" title="Elf" aria-label="Elf"></span></li>
-                        <li><strong>Top 3:</strong> <span class="name">nick3</span> <span class="class-badge sm" title="SM" aria-label="SM"></span></li>
-                      </ul>
-                </div>
+                <div>Top 1: <span class="name">nick1</span> <span class="class-badge bk" title="BK" aria-label="BK"></span></div>
               </div>
             </div>
-            </div>
-            <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
-          </div>
-
           </div>
         </section>
       </div>
@@ -260,38 +208,6 @@
       <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
     </div>
   </footer>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const slider = document.querySelector('.slider');
-      if(!slider) return;
-      const slides = slider.querySelectorAll('.slide');
-      const dots = slider.querySelectorAll('.dot');
-      const slidesContainer = slider.querySelector('.slides');
-      const toggleBtn = slider.querySelector('.slider__toggle');
-      const duration = parseFloat(getComputedStyle(slidesContainer).animationDuration) * 1000;
-      const interval = duration / slides.length;
-      let index = 0;
-      function activate(){
-        dots.forEach((d,i)=>d.classList.toggle('active', i===index));
-        index = (index + 1) % dots.length;
-      }
-      activate();
-      setInterval(activate, interval);
-      if(toggleBtn){
-        toggleBtn.addEventListener('click', ()=>{
-          const paused = slidesContainer.style.animationPlayState === 'paused';
-          if(paused){
-            slidesContainer.style.animationPlayState = '';
-            toggleBtn.setAttribute('aria-label','Pause animation');
-            toggleBtn.textContent = 'Pause';
-          }else{
-            slidesContainer.style.animationPlayState = 'paused';
-            toggleBtn.setAttribute('aria-label','Play animation');
-            toggleBtn.textContent = 'Play';
-          }
-        });
-      }
-    });
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/info.html
+++ b/info.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bakasta Mu — Informações</title>
+  <meta name="description" content="Informações sobre o servidor Bakasta Mu." />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container nav" role="navigation" aria-label="Navegação principal">
+      <a class="brand" href="index_bootstrap.html">
+        <span class="brand__badge">
+          <img src="img/logo.png" alt="Logo Bakasta Mu" />
+        </span>
+        <span>Bakasta <span class="muted">Mu</span></span>
+      </a>
+      <nav class="menu" aria-label="Menu">
+        <a href="index_bootstrap.html#home">Início</a>
+        <a href="downloads.html">Downloads</a>
+        <a href="index_bootstrap.html#ranking">Ranking</a>
+        <a href="usuario.html">Usuário</a>
+        <a href="info.html">Informações</a>
+        <a href="#vip">Comprar VIP</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="container text-center py-4">
+      <h1>Informações</h1>
+    </div>
+  </section>
+
+  <main class="container my-4">
+    <section class="card" aria-labelledby="info-ttl">
+      <header class="card__hdr"><h2 id="info-ttl" class="card__title m-0">Informações</h2></header>
+      <div class="card__body">
+        <p>Detalhes do servidor em breve.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>© <span id="y">2025</span> Bakasta Mu. Fan project sem vínculo com Webzen — marcas são de seus respectivos donos.</p>
+      <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
+    </div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -98,55 +98,12 @@ a{color:inherit;text-decoration:none}
 @media (min-width:640px){.rank-grid{grid-template-columns:1fr 1fr}}
 .rank-card{background:var(--panel2);border:1px solid var(--border);border-radius:.8rem;padding:.9rem;display:grid;gap:.25rem;transition:border-color .2s,background-color .2s}
 .rank-card small{color:var(--muted)}
-
-/* ---------- Slider CSS Top 1-3 com auto-rotação ---------- */
-.slider{position:relative;margin-top:1rem;border:1px dashed var(--border);border-radius:.6rem;overflow:hidden;display:flex;flex-direction:column;min-height:420px;flex:1}
-.slider.glow{ border: var(--glow-size) solid transparent; /* força o gradiente da classe .glow */ }
-@media (max-width:640px){.slider{min-height:280px}}
-.slides{display:flex;width:400%;height:100%;flex:1;will-change:transform;animation:autoroll4 15s linear infinite}
-.slide{flex:0 0 100%;position:relative;display:flex;flex-direction:column;height:100%;background:linear-gradient(180deg,#15151d,#0b0b0e);border-right:1px solid var(--border);box-shadow:inset 1px 0 0 rgba(255,255,255,.03), inset -1px 0 0 rgba(0,0,0,.5)}
-/* imagem: default + custom override por inline style */
-.slide__img{position:absolute;inset:0;z-index:0;}
-.slide__img img{width:100%;height:100%;object-fit:contain;object-position:center}
-.legend{position:absolute;left:0;right:0;bottom:0;display:grid;gap:.35rem;padding:0 1rem 1rem;z-index:3}
-.legend__box{position:relative;background:rgba(0,0,0,.6);backdrop-filter:blur(2px);border:1px solid var(--border);border-radius:.8rem;padding:.9rem;box-shadow:0 8px 24px rgba(0,0,0,.35);max-width:780px;width:min(780px,96%);margin:0 auto;display:grid;gap:.5rem;color:var(--txt)}
-.legend__title{margin:0 0 .35rem 0;font-weight:900}
-.toplist{list-style:none;margin:0;padding:0;display:grid;gap:.35rem}
-.toplist li{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:.5rem}
-.toplist strong{font-weight:900}
-.toplist .name{font-weight:700}
+/* Badges de classe para rankings */
 .class-badge{display:inline-block;width:22px;height:22px;border-radius:4px;border:1px solid var(--border);background:#0b0b0e;background-size:cover;background-position:center}
-/* placeholders embutidos para classes (BK/SM/ELF/MG) */
 .class-badge.bk{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%23171722%22/><text x=%225%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>BK</text></svg>')}
 .class-badge.sm{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%23131d26%22/><text x=%224%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>SM</text></svg>')}
 .class-badge.elf{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%23162318%22/><text x=%224%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>EL</text></svg>')}
 .class-badge.mg{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%231a1a1a%22/><text x=%224%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>MG</text></svg>')}
-.dots{position:absolute;bottom:8px;left:0;right:0;display:flex;justify-content:center;gap:.4rem;z-index:5}
-.dot{width:10px;height:10px;border-radius:999px;border:1px solid var(--border);background:#0b0b0e;opacity:.4;transition:opacity .3s,background .3s}
-.dot.active{background:var(--accent);opacity:1}
-.slider:hover .slides{animation-play-state:paused}
-.slider:focus-within .slides{animation-play-state:paused}
-.slider__toggle{
-  position:absolute;
-  width:1px;height:1px;margin:-1px;border:0;padding:0;
-  clip:rect(0 0 0 0);clip-path:inset(50%);overflow:hidden;white-space:nowrap
-}
-
-/* ornament / boundary cues for slider */
-.slider::before{content:"";position:absolute;inset:0;pointer-events:none;background:
-  linear-gradient(90deg, rgba(11,11,14,1), rgba(11,11,14,0) 10%, rgba(11,11,14,0) 90%, rgba(11,11,14,1)),
-  linear-gradient(180deg, transparent 0%, rgba(11,11,14,0.8) 100%);z-index:2}
-
-
-/* legend header with icon (default placeholder) */
-.legend__head{display:flex;align-items:center;gap:.6rem}
-.legend__icon{width:28px;height:28px;border-radius:6px;border:1px solid var(--border);background:#0b0b0e;background-size:cover;background-position:center;background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24"><rect width="24" height="24" rx="6" fill="%23121218"/><path d="M7 5h10v3a4 4 0 0 1-3 3.87V14h-4v-2.13A4 4 0 0 1 7 8V5zM5 5h2v3a2 2 0 0 0 2 2v1H7a2 2 0 0 1-2-2V5zm12 0h2v4a2 2 0 0 1-2 2h-2V10a2 2 0 0 0 2-2V5z" fill="%23f59e0b"/></svg>')}
-/* Ícones por ranking */
-.legend__icon.icon-bc{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><rect width="28" height="28" rx="6" fill="%231a1629"/><text x="5" y="19" font-size="12" fill="%23f1f1f1" font-family="Arial" font-weight="700">BC</text></svg>')}
-.legend__icon.icon-ds{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><rect width="28" height="28" rx="6" fill="%23201818"/><text x="5" y="19" font-size="12" fill="%23f1f1f1" font-family="Arial" font-weight="700">DS</text></svg>')}
-.legend__icon.icon-pk{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><rect width="28" height="28" rx="6" fill="%23181f20"/><text x="5" y="19" font-size="12" fill="%23f1f1f1" font-family="Arial" font-weight="700">PK</text></svg>')}
-.legend__icon.icon-resets{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><rect width="28" height="28" rx="6" fill="%23161c12"/><text x="3" y="19" font-size="12" fill="%23f1f1f1" font-family="Arial" font-weight="700">RS</text></svg>')}
-
 /* Glow (borda iluminada) — reutilizável (sem -webkit-mask) */
 :root{ --glow-size:2px }
 .glow{
@@ -168,22 +125,6 @@ a{color:inherit;text-decoration:none}
     conic-gradient(from var(--glow-angle,0deg), #f59e0b, #ef4444, #f59e0b) border-box;
   animation: spinGlow 10s linear infinite;
 }
-
-/* Nova animação estável para 4 slides (sem "vazio" no loop) */
-@keyframes autoroll4{
-  0%,24.999%{transform:translateX(0)}
-  25%,49.999%{transform:translateX(-100%)}
-  50%,74.999%{transform:translateX(-200%)}
-  75%,99.999%{transform:translateX(-300%)}
-  100%{transform:translateX(0)}
-}
-
-/* helpers de preenchimento */
-.fillrow{display:flex;flex-direction:column;gap:1rem;min-height:0}
-.fill{flex:1;display:flex;flex-direction:column;min-height:0}
-
-/* respeita acessibilidade: se o sistema pedir menos movimento, congela o slider */
-@media (prefers-reduced-motion: reduce){ .slides{animation:none !important;} }
 
 /* ---------- Utils ---------- */
 .muted{color:var(--muted)}

--- a/usuario.html
+++ b/usuario.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bakasta Mu — Usuário</title>
+  <meta name="description" content="Página do usuário do Bakasta Mu." />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container nav" role="navigation" aria-label="Navegação principal">
+      <a class="brand" href="index_bootstrap.html">
+        <span class="brand__badge">
+          <img src="img/logo.png" alt="Logo Bakasta Mu" />
+        </span>
+        <span>Bakasta <span class="muted">Mu</span></span>
+      </a>
+      <nav class="menu" aria-label="Menu">
+        <a href="index_bootstrap.html#home">Início</a>
+        <a href="downloads.html">Downloads</a>
+        <a href="index_bootstrap.html#ranking">Ranking</a>
+        <a href="usuario.html">Usuário</a>
+        <a href="info.html">Informações</a>
+        <a href="#vip">Comprar VIP</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="container text-center py-4">
+      <h1>Página do Usuário</h1>
+    </div>
+  </section>
+
+  <main class="container my-4">
+    <section class="card" aria-labelledby="user-ttl">
+      <header class="card__hdr"><h2 id="user-ttl" class="card__title m-0">Usuário</h2></header>
+      <div class="card__body">
+        <p>Área do usuário em construção.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>© <span id="y">2025</span> Bakasta Mu. Fan project sem vínculo com Webzen — marcas são de seus respectivos donos.</p>
+      <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
+    </div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- substitui o slider de ranking por cards retangulares mostrando o Top 1 de cada categoria
- inclui carrossel de imagens após a seção de Últimas Notícias
- cria páginas estáticas de Downloads, Usuário e Informações seguindo o layout existente

## Testing
- `npm test` *(erro: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a8c289688323b6f91c0f1dbf60d1