### PR TITLE
Add gallery and gate user section behind login

### DIFF
--- a/index_bootstrap.html
+++ b/index_bootstrap.html
@@ -46,7 +46,7 @@
     <div class="row g-4 align-items-stretch">
       <!-- Esquerda -->
       <div class="col-lg-8 d-flex">
-        <section class="card w-100" aria-labelledby="ttl-news">
+        <section class="card card--compact w-100" aria-labelledby="ttl-news">
           <header class="card__hdr d-flex justify-content-between align-items-center">
             <h2 id="ttl-news" class="card__title m-0">Últimas Notícias</h2>
             <span class="pill">Feed</span>
@@ -70,27 +70,6 @@
                 </div>
               </article>
             </div>
-            <div id="newsCarousel" class="carousel slide mt-3" data-bs-ride="carousel">
-              <div class="carousel-inner">
-                <div class="carousel-item active">
-                  <img src="img/slide1.jpg" class="d-block w-100" alt="Imagem 1" />
-                </div>
-                <div class="carousel-item">
-                  <img src="img/slide2.jpeg" class="d-block w-100" alt="Imagem 2" />
-                </div>
-                <div class="carousel-item">
-                  <img src="img/slide3.png" class="d-block w-100" alt="Imagem 3" />
-                </div>
-              </div>
-              <button class="carousel-control-prev" type="button" data-bs-target="#newsCarousel" data-bs-slide="prev">
-                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Anterior</span>
-              </button>
-              <button class="carousel-control-next" type="button" data-bs-target="#newsCarousel" data-bs-slide="next">
-                <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Próximo</span>
-              </button>
-            </div>
           </div>
         </section>
       </div>
@@ -110,7 +89,7 @@
                   <span class="muted">Senha</span>
                   <input class="input" type="password" name="password" placeholder="••••••••" aria-label="Senha" />
                 </label>
-                <button class="btn btn--primary" type="button">Entrar</button>
+                <button class="btn btn--primary" type="button" id="loginBtn">Entrar</button>
                 <button class="btn btn--secondary" type="button">Cadastrar</button>
                 <p class="hint">⚠️ Ilustrativo. Ao implementar, use HTTPS, CSRF, rate limit e hashing forte (Argon2/BCrypt).</p>
               </form>
@@ -136,7 +115,7 @@
     <div class="row g-4 align-items-stretch mt-1">
       <!-- Esquerda -->
       <div class="col-lg-8 d-flex">
-        <section class="card w-100" aria-labelledby="ranks-title">
+        <section class="card card--compact w-100" aria-labelledby="ranks-title">
           <header class="card__hdr d-flex justify-content-between align-items-center">
             <h2 id="ranks-title" class="card__title m-0">Rankings</h2>
             <span class="pill">Hall, PK, Eventos</span>
@@ -188,16 +167,53 @@
             </div>
           </section>
 
-          <section class="card flex-fill" aria-labelledby="guide-ttl">
-            <header class="card__hdr"><h2 id="guide-ttl" class="card__title m-0">Guia Rápido</h2></header>
-            <div class="card__body d-grid gap-2">
-              <a class="rank-card" href="#downloads"><strong>Downloads</strong><small>Cliente, patch, anti-cheat</small></a>
-              <a class="rank-card" href="#regras"><strong>Regras</strong><small>Jogabilidade e conduta</small></a>
-              <a class="rank-card" href="#discord"><strong>Discord</strong><small>Suporte e comunidade</small></a>
-              <div class="guide__row"><span>Dica do Dia</span><span class="pill">Use /post com moderação</span></div>
-            </div>
-          </section>
         </div>
+      </div>
+    </div>
+
+    <!-- ROW 3: Galeria (esq) | Guia (dir) -->
+    <div class="row g-4 align-items-stretch mt-1">
+      <!-- Esquerda -->
+      <div class="col-lg-8 d-flex">
+        <section class="card w-100" aria-labelledby="gallery-ttl">
+          <header class="card__hdr"><h2 id="gallery-ttl" class="card__title m-0">Galeria</h2></header>
+          <div class="card__body">
+            <div id="galleryCarousel" class="carousel slide" data-bs-ride="carousel">
+              <div class="carousel-inner">
+                <div class="carousel-item active">
+                  <img src="img/slide1.jpg" class="d-block w-100" alt="Imagem 1" />
+                </div>
+                <div class="carousel-item">
+                  <img src="img/slide2.jpeg" class="d-block w-100" alt="Imagem 2" />
+                </div>
+                <div class="carousel-item">
+                  <img src="img/slide3.png" class="d-block w-100" alt="Imagem 3" />
+                </div>
+              </div>
+              <button class="carousel-control-prev" type="button" data-bs-target="#galleryCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Anterior</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#galleryCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Próximo</span>
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <!-- Direita -->
+      <div class="col-lg-4 d-flex">
+        <section class="card flex-fill" aria-labelledby="guide-ttl">
+          <header class="card__hdr"><h2 id="guide-ttl" class="card__title m-0">Guia Rápido</h2></header>
+          <div class="card__body d-grid gap-2">
+            <a class="rank-card" href="#downloads"><strong>Downloads</strong><small>Cliente, patch, anti-cheat</small></a>
+            <a class="rank-card" href="#regras"><strong>Regras</strong><small>Jogabilidade e conduta</small></a>
+            <a class="rank-card" href="#discord"><strong>Discord</strong><small>Suporte e comunidade</small></a>
+            <div class="guide__row"><span>Dica do Dia</span><span class="pill">Use /post com moderação</span></div>
+          </div>
+        </section>
       </div>
     </div>
   </main>
@@ -208,6 +224,12 @@
       <p class="mt-3">Layout leve. Substitua textos e números por conteúdo dinâmico quando integrar ao backend.</p>
     </div>
   </footer>
+  <script>
+    document.getElementById('loginBtn')?.addEventListener('click', () => {
+      localStorage.setItem('loggedIn', 'true');
+      window.location.href = 'usuario.html';
+    });
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/usuario.html
+++ b/usuario.html
@@ -9,6 +9,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <script>
+    if (!localStorage.getItem('loggedIn')) {
+      window.location.href = 'index_bootstrap.html';
+    }
+  </script>
   <header class="topbar">
     <div class="container nav" role="navigation" aria-label="Navegação principal">
       <a class="brand" href="index_bootstrap.html">
@@ -38,7 +43,15 @@
     <section class="card" aria-labelledby="user-ttl">
       <header class="card__hdr"><h2 id="user-ttl" class="card__title m-0">Usuário</h2></header>
       <div class="card__body">
-        <p>Área do usuário em construção.</p>
+        <section class="mb-3">
+          <h3>Conta</h3>
+          <p>Informações da sua conta aparecerão aqui.</p>
+        </section>
+        <section>
+          <h3>Personagens</h3>
+          <p>Detalhes dos seus personagens aparecerão aqui.</p>
+        </section>
+        <button class="btn btn--secondary mt-3" type="button" onclick="localStorage.removeItem('loggedIn'); window.location.href='index_bootstrap.html';">Sair</button>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- make news and ranking cards compact and introduce gallery carousel
- move quick guide next to gallery for balanced layout
- protect user area behind a login flag with account and character placeholders

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ad4e4f048323bf422180d807d400