### PR TITLE
Limit news and gallery heights to fix sidebar stretching

### DIFF
--- a/index_bootstrap.html
+++ b/index_bootstrap.html
@@ -172,9 +172,9 @@
     </div>
 
     <!-- ROW 3: Galeria (esq) | Guia (dir) -->
-    <div class="row g-4 align-items-stretch mt-1">
+    <div class="row g-4 align-items-start mt-1">
       <!-- Esquerda -->
-      <div class="col-lg-8 d-flex">
+      <div class="col-lg-8">
         <section class="card w-100" aria-labelledby="gallery-ttl">
           <header class="card__hdr"><h2 id="gallery-ttl" class="card__title m-0">Galeria</h2></header>
           <div class="card__body">
@@ -204,8 +204,8 @@
       </div>
 
       <!-- Direita -->
-      <div class="col-lg-4 d-flex">
-        <section class="card flex-fill" aria-labelledby="guide-ttl">
+      <div class="col-lg-4">
+        <section class="card" aria-labelledby="guide-ttl">
           <header class="card__hdr"><h2 id="guide-ttl" class="card__title m-0">Guia Rápido</h2></header>
           <div class="card__body d-grid gap-2">
             <a class="rank-card" href="#downloads"><strong>Downloads</strong><small>Cliente, patch, anti-cheat</small></a>

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ a{color:inherit;text-decoration:none}
 .card--compact .card__body{padding:.7rem 1rem}
 
 /* ---------- Notícias ---------- */
-.news{display:flex;flex-direction:column;gap:.6rem;min-height:0}
+.news{display:flex;flex-direction:column;gap:.6rem;min-height:0;max-height:300px;overflow-y:auto}
 .news__item{display:grid;grid-template-columns:33px 1fr;gap:.75rem;padding:1rem;border-bottom:1px dashed var(--border)}
 .news__item:last-child{border-bottom:0}
 .news__icon{display:grid;place-items:center;color:var(--accent)}
@@ -98,6 +98,10 @@ a{color:inherit;text-decoration:none}
 @media (min-width:640px){.rank-grid{grid-template-columns:1fr 1fr}}
 .rank-card{background:var(--panel2);border:1px solid var(--border);border-radius:.8rem;padding:.9rem;display:grid;gap:.25rem;transition:border-color .2s,background-color .2s}
 .rank-card small{color:var(--muted)}
+
+/* ---------- Galeria ---------- */
+.carousel-item img{height:250px;object-fit:cover}
+
 /* Badges de classe para rankings */
 .class-badge{display:inline-block;width:22px;height:22px;border-radius:4px;border:1px solid var(--border);background:#0b0b0e;background-size:cover;background-position:center}
 .class-badge.bk{background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2222%22 height=%2222%22 viewBox=%220 0 22 22%22><rect width=%2222%22 height=%2222%22 rx=%224%22 fill=%22%23171722%22/><text x=%225%22 y=%2216%22 font-size=%2210%22 fill=%22%23ffffff%22 font-family=%22Arial%22>BK</text></svg>')}


### PR DESCRIPTION
## Summary
- cap news feed height and enable scroll to avoid expanding sidebar
- restrict gallery image height and remove column stretching so Quick Guide cards stay compact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af35abac83238e7de4a750231efa