### PR TITLE
feat: enhance user account page

### DIFF
--- a/style.css
+++ b/style.css
@@ -120,6 +120,18 @@ a{color:inherit;text-decoration:none}
 .rank-card{background:var(--panel2);border:1px solid var(--border);border-radius:.8rem;padding:.9rem;display:grid;gap:.25rem;transition:border-color .2s,background-color .2s}
 .rank-card small{color:var(--muted)}
 
+/* ---------- Personagens ---------- */
+.char-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
+.char-card{display:flex;gap:.75rem;align-items:center;background:var(--panel2);border:1px solid var(--border);border-radius:.8rem;padding:.9rem}
+.char-card img{width:64px;height:64px;border-radius:.5rem;object-fit:cover}
+.char-info{flex:1}
+.char-info h4{margin:0;font-weight:800}
+.char-meta{color:var(--muted);font-size:.875rem;margin:.25rem 0 .5rem}
+.btn-sm{padding:.35rem .6rem;font-size:.85rem}
+.info-list{list-style:none;margin:0;padding:0;display:grid;gap:.4rem}
+.info-list li{display:flex;flex-wrap:wrap;gap:.5rem}
+.info-list strong{color:var(--muted);min-width:120px}
+
 /* ---------- Galeria ---------- */
 .carousel-item img{height:325px;object-fit:cover}
 

--- a/usuario.html
+++ b/usuario.html
@@ -50,37 +50,86 @@
     </div>
   </header>
 
-  <section class="hero">
+  <section class="hero" style="background: linear-gradient(rgba(0,0,0,.6),rgba(0,0,0,.6)), url('img/slide4.jpg') center/cover no-repeat;">
     <div class="container text-center py-4">
-      <h1>Página do Usuário</h1>
+      <h1>Minha Conta</h1>
     </div>
   </section>
 
   <main class="container my-4">
-    <section class="card" aria-labelledby="user-ttl">
-      <header class="card__hdr"><h2 id="user-ttl" class="card__title m-0">Usuário</h2></header>
-      <div class="card__body">
-        <section class="mb-3">
-          <h3>Conta</h3>
-          <p>Informações da sua conta aparecerão aqui.</p>
-        </section>
-        <section>
-          <h3>Personagens</h3>
-          <p>Detalhes dos seus personagens aparecerão aqui.</p>
-        </section>
-        <section id="senha" class="mt-3">
-          <h3>Resetar Senha</h3>
-          <form class="form" action="#" method="post" autocomplete="off" novalidate>
-            <label>
-              <span class="muted">Nova Senha</span>
-              <input class="input" type="password" placeholder="Nova senha" />
-            </label>
-            <button class="btn btn--primary mt-2" type="button">Resetar Senha</button>
-          </form>
-        </section>
-        <button class="btn btn--secondary mt-3" type="button" onclick="localStorage.removeItem('loggedIn'); window.location.href='index_bootstrap.html';">Sair</button>
-      </div>
-    </section>
+    <div class="stack">
+      <section class="card" aria-labelledby="chars-ttl">
+        <header class="card__hdr"><h2 id="chars-ttl" class="card__title m-0">Personagens</h2></header>
+        <div class="card__body">
+          <div class="char-grid">
+            <article class="char-card">
+              <img src="img/slide1.jpg" alt="Spray3D" />
+              <div class="char-info">
+                <h4>Spray3D</h4>
+                <p class="char-meta">Soul Master | 271 resets | Nível 350</p>
+                <a href="#" class="btn btn--primary btn-sm">Ver PJ</a>
+              </div>
+            </article>
+            <article class="char-card">
+              <img src="img/slide2.jpeg" alt="Elfisio" />
+              <div class="char-info">
+                <h4>Elfisio</h4>
+                <p class="char-meta">Muse Elf | 360 resets | Nível 350</p>
+                <a href="#" class="btn btn--primary btn-sm">Ver PJ</a>
+              </div>
+            </article>
+            <article class="char-card">
+              <img src="img/slide3.png" alt="Bk-Casla" />
+              <div class="char-info">
+                <h4>Bk-Casla</h4>
+                <p class="char-meta">Blade Knight | 0 resets | Nível 1</p>
+                <a href="#" class="btn btn--primary btn-sm">Ver PJ</a>
+              </div>
+            </article>
+            <article class="char-card">
+              <img src="img/slide1.png" alt="MagicClick" />
+              <div class="char-info">
+                <h4>MagicClick</h4>
+                <p class="char-meta">Magic Gladiator | 0 resets | Nível 1</p>
+                <a href="#" class="btn btn--primary btn-sm">Ver PJ</a>
+              </div>
+            </article>
+            <article class="char-card">
+              <img src="img/slide4.jpg" alt="BLIND" />
+              <div class="char-info">
+                <h4>BLIND</h4>
+                <p class="char-meta">Fairy Elf | 360 resets | Nível 2</p>
+                <a href="#" class="btn btn--primary btn-sm">Ver PJ</a>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="card" aria-labelledby="info-ttl">
+        <header class="card__hdr"><h2 id="info-ttl" class="card__title m-0">Informações da Conta</h2></header>
+        <div class="card__body">
+          <ul class="info-list">
+            <li><strong>Criação:</strong> 16/11/2017</li>
+            <li><strong>Email:</strong> g****@hotmail.com</li>
+            <li><strong>Último login:</strong> 25/05/2023 18:45 — personagem Elfisio</li>
+            <li><strong>Zen no site:</strong> 4.700.000</li>
+          </ul>
+
+          <section id="senha" class="mt-3">
+            <h3>Resetar Senha</h3>
+            <form class="form" action="#" method="post" autocomplete="off" novalidate>
+              <label>
+                <span class="muted">Nova Senha</span>
+                <input class="input" type="password" placeholder="Nova senha" />
+              </label>
+              <button class="btn btn--primary mt-2" type="button">Resetar Senha</button>
+            </form>
+          </section>
+          <button class="btn btn--secondary mt-3" type="button" onclick="localStorage.removeItem('loggedIn'); window.location.href='index_bootstrap.html';">Sair</button>
+        </div>
+      </section>
+    </div>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- redesign user account page with character grid and account details
- add styles for character cards and info sections

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d34a17308323b724de796c1934cb